### PR TITLE
feat: Adding paper sounds for paper and maps

### DIFF
--- a/src/main/generated/packed/assets/minecraft/sounds/items/papers.json
+++ b/src/main/generated/packed/assets/minecraft/sounds/items/papers.json
@@ -1,0 +1,8 @@
+{
+  "keys": [
+    "minecraft:paper",
+    "minecraft:map",
+    "minecraft:filled_map"
+  ],
+  "soundEvent": "minecraft:item.book.page_turn"
+}

--- a/src/main/java/dev/imb11/sounds/loaders/fabric/datagen/DynamicItemSounds.java
+++ b/src/main/java/dev/imb11/sounds/loaders/fabric/datagen/DynamicItemSounds.java
@@ -187,6 +187,11 @@ public class DynamicItemSounds extends SoundDefinitionProvider<Item> {
         provider.accept("dyes", create(SoundEvents.ITEM_DYE_USE)
                 .addKey(ConventionalItemTags.DYES));
 
+        provider.accept("papers", create(SoundEvents.ITEM_BOOK_PAGE_TURN)
+                .addKey(Items.PAPER)
+                .addKey(Items.FILLED_MAP)
+                .addKey(Items.MAP));
+
         provider.accept("fireworks", create(SoundEvents.BLOCK_BAMBOO_SAPLING_HIT)
                 .addKey(Items.FIREWORK_ROCKET));
 


### PR DESCRIPTION
I was working on [a resource pack to add more mod support](https://github.com/Fydar/SoundsIntegration) and I noticed that paper and maps where missing a sound. Minecraft has sounds from turning pages in a **Book and Quill** and so I added them.

Here's a Resource Pack that you can add if you would like to test out the change for yourself.

[AddingPaper.zip](https://github.com/user-attachments/files/17295625/AddingPaper.zip)

And here's a short video of the sound in-game.

https://github.com/user-attachments/assets/c9b64a91-fc2a-4469-86a1-6bac1bbd58cb