### PR TITLE
changed attenuation to none when spp is installed

### DIFF
--- a/src/main/java/dev/imb11/sounds/api/context/DynamicSoundContext.java
+++ b/src/main/java/dev/imb11/sounds/api/context/DynamicSoundContext.java
@@ -15,8 +15,8 @@ public interface DynamicSoundContext<T> {
 
     default SimpleSoundInstance createSoundInstance(ResourceLocation event, float pitch, float volume) {
         var pos = Vec3.ZERO;
-        if (LoaderUtils.isModInstalled("sound_physics_perfected") && Minecraft.getInstance().player != null)
-            pos = Minecraft.getInstance().player.position();
+        if (LoaderUtils.isModInstalled("sound_physics_perfected"))
+            return new SimpleSoundInstance(event, SoundSource.MASTER, volume, pitch, SoundsClient.RANDOM, false, 0, SoundInstance.Attenuation.NONE, pos.x, pos.y, pos.z, true); // Disable Attenuation when using SPP
 
         return new SimpleSoundInstance(event, SoundSource.MASTER, volume, pitch, SoundsClient.RANDOM, false, 0, SoundInstance.Attenuation.LINEAR, pos.x, pos.y, pos.z, true);
     }


### PR DESCRIPTION
Changed the attenuation mode to NONE when Sound Physics Perfected is installed to make SPP skip processing of all Sounds mod sounds.

lmk if there is a reason for having it on linear, in which case i will look into it further on my mod's end.
(I've been testing with it for a bit and haven't noticed anything strange)